### PR TITLE
Make sure barnyard_user can be determined in a worktree dir.

### DIFF
--- a/barnyard
+++ b/barnyard
@@ -692,7 +692,7 @@ function barnyard_apply {
             [[ -d "$o_barnyard[repository]" ]] || abend 'no barnyard at path %s' "${o_barnyard[repository]:q}"
 
             typeset barnyard_user
-            barnyard_user=$(stat -c '%U' "${o_barnyard[repository]}/conf/.git/index") || abend 'not a git repo %s' "$o_barnyard[repository]"
+            barnyard_user=$(stat -c '%U' "$(git -C "${o_barnyard[repository]}/conf" rev-parse --git-dir)/index") || abend 'not a git repo %s' "$o_barnyard[repository]/conf"
 
             [[ "$barnyard_user" == $SUDO_USER ]] || abend 'sudo user %s does not own %s' "$SUDO_USER" "${o_barnyard[repository]:q}"
 


### PR DESCRIPTION
If I have the following directories on a machine:

```
barnyard/
acreops-barnyard/
    conf/
    code/
```

And `conf` and `code` are worktree directories for a headless `acreops-barnyard/.git`, barnyard can't find the `index` file for `acreops-barnyard/conf`. I found that `git rev-parse --git-dir` will return `.git` for a normal repo and `.git/worktree/[tree]` for a worktree repo, so that will give us the location to search for the `index` file.
